### PR TITLE
Fix the data packing

### DIFF
--- a/code/encoder-module-code/encoder-module-code.ino
+++ b/code/encoder-module-code/encoder-module-code.ino
@@ -501,10 +501,8 @@ void updateEncoder() {
     offset = -count;
     offsetInitialised = true;
   }
-
   encoderCount.val = (revolutions * 4092) + (count + offset);
-  encoderCount.val = (encoderCount.val & ~((long)7 << 21)) | (((long)magStrength << 22)); //clear the upper three bits of the third byte, insert the two-bit magStrength value at bits 23 and 22
-  encoderCount.val |= ((((long)1<<31) & encoderCount.val) >> 10); //shift the sign bit from bit 31 to bit 21
+  encoderCount.val = ((encoderCount.val &~((long)3 << 22)) | ((long)magStrength << 22)); //clear the upper two bits of the third byte, insert the two-bit magStrength value
 }
 
 int readPosition() {


### PR DESCRIPTION
This is all that is needed to pack in the magnetic strength value since all the most significant bits are the same value as the sign bit until you get to really high values.